### PR TITLE
Feature/issues26

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,7 +2,8 @@ CREATE TABLE IF NOT EXISTS `users` (
   `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `login` varchar(255) NOT NULL UNIQUE,
   `password_hash` varchar(255) NOT NULL,
-  `salt` varchar(255) NOT NULL
+  `salt` varchar(255) NOT NULL,
+  `failure_time` INT DEFAULT 0 NOT NULL
 ) DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `login_log` (


### PR DESCRIPTION
#26 
- users table にログイン失敗カウントのカラムを追加
- ユーザーがログイン失敗時に、失敗カウントをインクリメントさせる(ログイン成功でカウントリセット)  
- ユーザーがロックされているかの判定をuser テーブルの失敗カウントから計算するように変更