### PR TITLE
Feature/issues33

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -14,3 +14,9 @@ CREATE TABLE IF NOT EXISTS `login_log` (
   `ip` varchar(255) NOT NULL,
   `succeeded` tinyint NOT NULL
 ) DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `login_ip` (
+  `ip` varchar(255) NOT NULL PRIMARY KEY,
+  `failure_time` INT DEFAULT 0 NOT NULL
+  `is_locked` tinyint INT DEFAULT 0 NOT NULL
+) DEFAULT CHARSET=utf8;

--- a/webapp/go/db.go
+++ b/webapp/go/db.go
@@ -31,7 +31,7 @@ func createLoginLog(succeeded bool, remoteAddr, login string, user *User) error 
 		//	user.ID)
 
 		db.Exec(
-			" INSERT INTO login_ip(ip) VALUES(?) ON DUPLICATE KEY UPDATE failure_time=0",
+			"INSERT INTO login_ip(ip) VALUES(?) ON DUPLICATE KEY UPDATE failure_time=0",
 			remoteAddr)
 	}
 


### PR DESCRIPTION
#33 
- ログインされたIP格納用テーブル作成
- ログインIPを履歴保存 
- ログイン失敗で失敗カウント+1、成功でカウントリセット
- ipバンの判定をログインIPの失敗カウントから取得
- ユーザーのログイン失敗カウントアップ判定を失敗時のみするように修正